### PR TITLE
Adopt multiple lines of messages

### DIFF
--- a/agent-send.sh
+++ b/agent-send.sh
@@ -74,15 +74,18 @@ send_message() {
         # macOS: pbcopy/pbpaste使用
         echo -n "$message" | pbcopy
         tmux send-keys -t "$target" C-v
+        sleep 0.3
     elif command -v xclip >/dev/null 2>&1; then
         # Linux: xclip使用
         echo -n "$message" | xclip -selection clipboard
         tmux send-keys -t "$target" C-S-v
+        sleep 0.3
     else
         # クリップボードが使用できない場合は直接送信
         # tmuxのpaste-bufferを使用
         tmux set-buffer "$message"
         tmux paste-buffer -t "$target"
+        sleep 0.3
     fi
     
     # エンター押下で送信完了


### PR DESCRIPTION
# Issue

When the president, boss1 and workers send multi-line messages, the `agent-send.sh` script fails to deliver them. To address this, an alternative method for sending messages, such as utilizing clipboard functionalities, has been introduced.

# Solution

Implement to use clipboard-like features to enable message delivery.